### PR TITLE
permit tjone270/branding.py to show map credits

### DIFF
--- a/python/minqlx/_core.py
+++ b/python/minqlx/_core.py
@@ -219,15 +219,16 @@ def set_plugins_version(path):
     setattr(minqlx, "__plugins_version__", "{}-{}".format(version, branch))
 
 def set_map_subtitles():
-    cs = minqlx.get_configstring(678)
-    if cs:
-        cs += " - "
-    minqlx.set_configstring(678, cs + "Running minqlx ^6{}^7 with plugins ^6{}^7."
-        .format(minqlx.__version__, minqlx.__plugins_version__))
-    cs = minqlx.get_configstring(679)
-    if cs:
-        cs += " - "
-    minqlx.set_configstring(679, cs + "Check ^6http://github.com/MinoMino/minqlx^7 for more details.")
+    if not (minqlx.get_cvar("qlx_minqlxSelfBrand", bool)):
+        cs = minqlx.get_configstring(678)
+        if cs:
+            cs += " - "
+        minqlx.set_configstring(678, cs + "Running minqlx ^6{}^7 with plugins ^6{}^7."
+            .format(minqlx.__version__, minqlx.__plugins_version__))
+        cs = minqlx.get_configstring(679)
+        if cs:
+            cs += " - "
+        minqlx.set_configstring(679, cs + "Check ^6http://github.com/MinoMino/minqlx^7 for more details.")
 
 # ====================================================================
 #                              DECORATORS
@@ -394,6 +395,7 @@ def initialize_cvars():
     minqlx.set_cvar_once("qlx_commandPrefix", "!")
     minqlx.set_cvar_once("qlx_logs", "2")
     minqlx.set_cvar_once("qlx_logsSize", str(3*10**6)) # 3 MB
+    minqlx.set_cvar_once("qlx_minqlxSelfBrand", "1")
     # Redis
     minqlx.set_cvar_once("qlx_redisAddress", "127.0.0.1")
     minqlx.set_cvar_once("qlx_redisDatabase", "0")

--- a/python/minqlx/_core.py
+++ b/python/minqlx/_core.py
@@ -219,7 +219,7 @@ def set_plugins_version(path):
     setattr(minqlx, "__plugins_version__", "{}-{}".format(version, branch))
 
 def set_map_subtitles():
-    if not (minqlx.get_cvar("qlx_minqlxSelfBrand", bool)):
+    if (minqlx.get_cvar("qlx_minqlxSelfBrand", bool)):
         cs = minqlx.get_configstring(678)
         if cs:
             cs += " - "


### PR DESCRIPTION
With my branding.py plugin (https://github.com/tjone270/Quake-Live/blob/master/minqlx-plugins/branding.py), I'd like to be able to show the original map author lines before the user-set branding. When I use the same method above to do so (lines 221/231, how you keep the author names before your minqlx branding), I get both the map credits, and the minqlx branding, and the branding set by the plugin user. 

If there's a cvar (qlx_minqlxSelfBrand in this case) that can disable your branding, I can then use the map credits with branding.py.
