### PR TITLE
kamikaze holdable fix

### DIFF
--- a/python_embed.c
+++ b/python_embed.c
@@ -1107,6 +1107,11 @@ static PyObject* PyMinqlx_SetHoldable(PyObject* self, PyObject* args) {
     else if (!g_entities[client_id].client)
         Py_RETURN_FALSE;
 
+    if (i == 37)  // 37 - kamikaze
+        g_entities[client_id].client->ps.eFlags |= EF_KAMIKAZE;
+    else
+        g_entities[client_id].client->ps.eFlags &= ~EF_KAMIKAZE;
+
     g_entities[client_id].client->ps.stats[STAT_HOLDABLE_ITEM] = i;
     Py_RETURN_TRUE;
 }


### PR DESCRIPTION
surrounding kamekaze skulls now appear on player.holdable = 'kamikaze'
Based on https://github.com/id-Software/Quake-III-Arena/blob/dbe4ddb10315479fc00086f08e25d968b4b43c49/code/game/g_items.c#L195-L204
plugin for testing: http://pastebin.com/biS2iBQe
Using magic number 37, 'cos couldn't find right constant for kamikaze holdable.