### PR TITLE
replace_items feature

### DIFF
--- a/quake_common.h
+++ b/quake_common.h
@@ -37,6 +37,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define CS_VOTE_STRING			9
 #define	CS_VOTE_YES				10
 #define	CS_VOTE_NO				11
+#define CS_ITEMS          15
 
 #define MAX_CLIENTS 64
 #define MAX_CHALLENGES  1024
@@ -1137,6 +1138,26 @@ typedef struct gitem_s {
   unsigned int maskGametypeRenderSkip;
   unsigned int maskGametypeForceSpawn;
 } gitem_t;
+
+typedef enum {
+  ET_GENERAL,
+  ET_PLAYER,
+  ET_ITEM,
+  ET_MISSILE,
+  ET_MOVER,
+  ET_BEAM,
+  ET_PORTAL,
+  ET_SPEAKER,
+  ET_PUSH_TRIGGER,
+  ET_TELEPORT_TRIGGER,
+  ET_INVISIBLE,
+  ET_GRAPPLE,       // grapple hooked on wall
+  ET_TEAM,
+
+  ET_EVENTS       // any of the EV_* events can be added freestanding
+              // by setting eType to ET_EVENTS + eventNum
+              // this avoids having to set eFlags and eventNum
+} entityType_t;
 
 struct gclient_s;
 


### PR DESCRIPTION
Added 2 methods:
- minqlx.replace_items(entity, item)
  - entity can be entity_id or entity_classname (depends on type). If entity_classname is used, method finds all entities with entity_classname and replaces with item
  - item can be item_id or item_classname. Classnames are defined here: https://github.com/id-Software/Quake-III-Arena/blob/dbe4ddb10315479fc00086f08e25d968b4b43c49/code/game/bg_misc.c (see bg_itemlist)
- minqlx.dev_print_items prints all items with entitiy ids in the map to game console
If output buffer is not enough, the other part is printed on server console. It is made like this 'cos
  - too many SV_SendServerCommand(NULL, "print ..) calls on one frame will kick player(s)
  - calling SV_SendServerCommand(NULL, "print \"%s\"", str) with very long str (>1024) just won't be printed to console for some reason.

minqlx.dev_print_items will be used if plugin developer wants to get entity id of certian item in the map and use it, for example, in minqlx.replace_items