### PR TITLE
Preserve lib path

### DIFF
--- a/bin/run_server_x64_minqlx.sh
+++ b/bin/run_server_x64_minqlx.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 cd "$(dirname "$0")"
 export LD_PRELOAD=$LD_PRELOAD:./minqlx.so
-LD_LIBRARY_PATH="./linux64" exec ./qzeroded.x64 "$@"
+LD_LIBRARY_PATH="./linux64:$LD_LIBRARY_PATH" exec ./qzeroded.x64 "$@"

--- a/bin/run_server_x86_minqlx.sh
+++ b/bin/run_server_x86_minqlx.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 cd "$(dirname "$0")"
 export LD_PRELOAD=$LD_PRELOAD:./minqlx.so
-LD_LIBRARY_PATH="." exec ./qzeroded.x86 "$@"
+LD_LIBRARY_PATH=".:$LD_LIBRARY_PATH" exec ./qzeroded.x86 "$@"


### PR DESCRIPTION
Hi, 

**Problem:**
Installing on CentOS7, LD_LIBRARY_PATH will be overridden and path to python3 libs will be missing. 
During start the following error will appear:
`./qzeroded.x64: error while loading shared libraries: libpython3.5m.so.1.0: cannot open shared object file: No such file or directory`

**Solution:**
Following fix allows to preserve existing LD_LIBRARY_PATH, only adding additional.

Best Regards,
sm