### PR TITLE
simple_hook rewrite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ CC = gcc
 CFLAGS += -shared -std=gnu11
 LDFLAGS_NOPY += -ldl
 LDFLAGS += $(shell python3.5-config --libs)
-SOURCES_NOPY += dllmain.c commands.c simple_hook.c hooks.c misc.c maps_parser.c
-SOURCES += dllmain.c commands.c python_embed.c python_dispatchers.c simple_hook.c hooks.c misc.c maps_parser.c
+SOURCES_NOPY += dllmain.c commands.c simple_hook.c hooks.c misc.c maps_parser.c trampoline.c
+SOURCES += dllmain.c commands.c python_embed.c python_dispatchers.c simple_hook.c hooks.c misc.c maps_parser.c trampoline.c
 OBJS = $(SOURCES:.c=.o)
 OBJS_NOPY = $(SOURCES_NOPY:.c=.o)
 OUTPUT = $(BINDIR)/minqlx.so

--- a/hooks.c
+++ b/hooks.c
@@ -313,29 +313,37 @@ void HookVm(void) {
 #ifndef NOPY
 	*(void**)(vm_call_table + RELOFFSET_VM_CALL_RUNFRAME) = My_G_RunFrame;
 
-	int res, failed = 0;
+	int res, failed = 0, count = 0;
 	res = Hook((void*)ClientConnect, My_ClientConnect, (void*)&ClientConnect);
 	if (res) {
 		DebugPrint("ERROR: Failed to hook ClientConnect: %d\n", res);
 		failed = 1;
 	}
+  count++;
 
     res = Hook((void*)G_StartKamikaze, My_G_StartKamikaze, (void*)&G_StartKamikaze);
     if (res) {
         DebugPrint("ERROR: Failed to hook G_StartKamikaze: %d\n", res);
         failed = 1;
     }
+    count++;
 
     res = Hook((void*)ClientSpawn, My_ClientSpawn, (void*)&ClientSpawn);
     if (res) {
         DebugPrint("ERROR: Failed to hook ClientSpawn: %d\n", res);
         failed = 1;
     }
+    count++;
 
 	if (failed) {
 		DebugPrint("Exiting.\n");
 		exit(1);
 	}
+
+    if ( !seek_hook_slot( -count ) ) {
+        DebugPrint("ERROR: Failed to rewind hook slot\nExiting.\n");
+        exit(1);
+    }
 #endif
 }
 

--- a/simple_hook.c
+++ b/simple_hook.c
@@ -82,3 +82,12 @@ int Hook(void* target, void* replacement, void** func_ptr) {
     last_trmp++;
     return 0;
 }
+
+int seek_hook_slot( int offset ) {
+
+    if ( (last_trmp + offset < 0) || (last_trmp + offset >= TRMPS_ARRAY_SIZE) )
+        return 0;
+
+    last_trmp += offset;
+    return 1;
+}

--- a/simple_hook.c
+++ b/simple_hook.c
@@ -1,5 +1,3 @@
-// TODO: Rewrite this crap.
-
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/mman.h>

--- a/simple_hook.c
+++ b/simple_hook.c
@@ -14,22 +14,21 @@ typedef uint64_t pint;
 typedef int64_t sint;
 #define WORST_CASE 			40
 #define JUMP_SIZE 			sizeof(JMP_ABS)
-#define TRMPS_ARRAY_SIZE	10240
 #elif defined(__i386) || defined(_M_IX86)
 typedef uint32_t pint;
 typedef int32_t sint;
 #define WORST_CASE 			29
 #define JUMP_SIZE 			sizeof(JMP_REL)
-#define TRMPS_ARRAY_SIZE	10240
 #endif
 
+#define TRMPS_ARRAY_SIZE	30
 const uint8_t NOP = 0x90;
 
 static void* trmps;
 static int last_trmp = 0; // trmp[TRMPS_ARRAY_SIZE]
 
 static void initializeTrampolines(void) {
-	trmps = mmap(NULL, (WORST_CASE * TRMPS_ARRAY_SIZE) + (JUMP_SIZE * TRMPS_ARRAY_SIZE),
+	trmps = mmap(NULL, (WORST_CASE * TRMPS_ARRAY_SIZE),
 		        PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
 }
 

--- a/simple_hook.c
+++ b/simple_hook.c
@@ -1,7 +1,5 @@
 // TODO: Rewrite this crap.
 
-#include <stdlib.h>
-#include <string.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/mman.h>

--- a/simple_hook.c
+++ b/simple_hook.c
@@ -7,28 +7,13 @@
 #include <sys/mman.h>
 #include <errno.h>
 #include <stdint.h>
-
-// For when we have an address and want to know exactly where it is
-// so we can edit it whenever needed.
-static int findAddress32(void* target, uint32_t address, size_t size) {
-	for (size_t i = 0; i < size; i++)
-		if (*(uint32_t*)((uint64_t)target + i) == address) return i;
-
-	return -1;
-}
-
-static int findAddress64(void* target, uint64_t address, size_t size) {
-	for (size_t i = 0; i < size; i++)
-		if (*(uint64_t*)((uint64_t)target + i) == address) return i;
-
-	return -1;
-}
+#include "trampoline.h"
 
 #if defined(__x86_64__) || defined(_M_X64)
 typedef uint64_t pint;
 typedef int64_t sint;
-#define WORST_CASE 			29
-#define JUMP_SIZE 			14 // Can be 6 in some cases, but 14 is worst-case.
+#define WORST_CASE 			40
+#define JUMP_SIZE 			14
 #define TRMPS_ARRAY_SIZE	10240
 #elif defined(__i386) || defined(_M_IX86)
 typedef uint32_t pint;
@@ -50,47 +35,18 @@ const uint8_t NOP = 0x90;
 
 static void* trmps;
 static int last_trmp = 0; // trmp[TRMPS_ARRAY_SIZE]
-// There are cases, especially in x64, we copy a relative <64 bit jump over to the trampoline,
-// but the trampoline is too far away from the intended jump that we can't even adjust it.
-// In those cases, we send the jump to an extra set of trampolines that we allocate along,
-// with the regular trampoline pool that holds a bunch of absolute jumps.
-static void* trmps_abs; // Right after trmps array in memory.
-static int last_trmp_abs = 0;
 
 static void initializeTrampolines(void) {
 	trmps = mmap(NULL, (WORST_CASE * TRMPS_ARRAY_SIZE) + (JUMP_SIZE * TRMPS_ARRAY_SIZE),
 		        PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-	trmps_abs = (void*)((pint)trmps + (WORST_CASE * TRMPS_ARRAY_SIZE));
 }
 
 #if defined(__x86_64__) || defined(_M_X64)
 #include "HDE/hde64.h"
 
-const uint8_t PUSH = 0x68;
-const uint32_t MOV_RSP4_DWORD = 0x042444C7;
-const uint8_t RET = 0xC3;
-
-static void makeJump(uint64_t target, uint64_t replacement) {
-	// Create an absolute "jump" to our replacement function.
-	*(uint8_t*)target = PUSH;
-	*(uint32_t*)(target + 1) = replacement;
-	if (replacement >> 32) {
-		// Need to fill the 32 MSB as well.
-		*(uint32_t*)(target + 5) = MOV_RSP4_DWORD;
-		*(uint32_t*)(target + 9) = replacement >> 32;
-		// Our target address is now on the stack. Let's return.
-		*(uint8_t*)(target + 13) = RET;
-	}
-	else {
-		// We just need to return here, since the address is already on the stack.
-		*(uint8_t*)(target + 5) = RET;
-	}
-}
-
 int Hook(void* target, void* replacement, void** func_ptr) {
-    int was_ret = 0, total_length = 0, difference = 0;
-    int bytes_needed, res, page_size, used_abs = 0;
-    hde64s hde;
+    TRAMPOLINE ct;
+    int res, page_size;
 
     // Check if our trampoline pool has been initialized. If not, do so.
     if (!trmps) {
@@ -100,83 +56,35 @@ int Hook(void* target, void* replacement, void** func_ptr) {
     	if (last_trmp + 1 > TRMPS_ARRAY_SIZE) return -3;
     }
 
-    // We can save a couple of bytes if the address can be expressed with the 32 LSB.
-    bytes_needed = ((uint64_t)replacement) >> 32 ? 14 : 6;
-
-    while (total_length < bytes_needed) {
-        total_length += hde64_disasm((void*)((uint64_t)target + total_length), &hde);
-        if ((hde.flags & F_ERROR) || was_ret) return -1;
-        else if (IS_RET(hde)) was_ret = 1; // We want to stay within the function.
-    }
-
-    difference = total_length - bytes_needed;
     void* trmp = (void*)((uint64_t)trmps + last_trmp * WORST_CASE);
 
-    // Copy the real function's initial bytes to our trampoline.
-    memcpy(trmp, target, total_length);
+    ct.pTarget     = target;
+    ct.pDetour     = replacement;
+    ct.pTrampoline = trmp;
 
-    // Check if we have any relative jumps we have to fix.
-	for (int len = 0; len < total_length; ) {
-		hde64_disasm((void*)((uint64_t)trmp + len), &hde);
-		if (IS_RELATIVE8(hde)) {
-			return -2;
-		}
-		else if ( IS_RELATIVE16(hde) ) {
-			return -3;
-		}
-		else if (IS_RELATIVE32(hde)) {
-			if (((uint64_t)trmp - (uint64_t)target) >> 32) {
-				// TODO: Can all relative stuff be rewritten to absolute?
-				//       In any case, we need a way to deal with this case.
-				return -5;
-			}
+    if (!CreateTrampolineFunction(&ct)) {
+        return -11;
+    }
 
-			int pos = findAddress32(trmp + len, hde.flags & F_DISP32 ? hde.disp.disp32 : hde.imm.imm32, hde.len);
-			if (pos == -1) return -4; // Should never happen, but just in case.
-
-			if (IS_CALL_OR_JUMP(hde)) {
-				uint64_t trmp_abs = (uint64_t)trmps_abs + (last_trmp_abs + used_abs) * JUMP_SIZE;
-				*(uint32_t*)((uint64_t)trmp + len + pos) = trmp_abs - (uint64_t)trmp + len + hde.len;
-				makeJump(trmp_abs, (uint64_t)target + total_length);
-				used_abs++;
-			}
-			else {
-				*(uint32_t*)((uint64_t)trmp + len + pos) -= (uint64_t)trmp - (uint64_t)target;
-			}
-		}
-		else if (IS_RELATIVE64(hde)) {
-			int pos = findAddress64(trmp + len, hde.imm.imm64, hde.len);
-			if (pos == -1) return -6; // Should never happen, but just in case.
-			*(uint64_t*)((uint64_t)trmp + len + pos) -= (uint64_t)trmp - (uint64_t)target;
-		}
-
-		len += hde.len;
-	}
-
-    // Temporarily make the .text page in question writable.
     page_size = sysconf(_SC_PAGESIZE);
     if (page_size == -1) return errno;
     res = mprotect((void*)((uint64_t)target & ~(page_size-1)), page_size, PROT_READ | PROT_WRITE | PROT_EXEC);
     if (res) return errno;
 
-    makeJump((uint64_t)target, (uint64_t)replacement);
-    //makeJump((uint64_t)target, (uint64_t)replacement, 1);
+    PJMP_ABS pJmp = (PJMP_ABS)target;
+    pJmp->opcode0 = 0xFF;
+    pJmp->opcode1 = 0x25;
+    pJmp->dummy   = 0;
+    pJmp->address = replacement;
 
-    // NOP out the rest, if any, out of courtesy. Removes broken opcodes.
-    for (int i = 0; i < difference; i++)
-        *(uint8_t*)((uint64_t)target + bytes_needed + i) = NOP;
-
-    // TODO: Use maps_parser instead of assuming read-exec.
-    res = mprotect((void*)((uint64_t)target & ~(page_size-1)), page_size, PROT_READ | PROT_EXEC);
-    if (res) return errno;
-
-    // Create a jump back to the rest of the real function on trampoline.
-    makeJump((uint64_t)trmp + total_length, (uint64_t)target + total_length);
+    int difference = ct.newIPs[ ct.nIP - 1 ];
+    for (int i=sizeof(JMP_ABS); i<difference; i++) {
+        *(uint8_t*)((uint64_t)target + i) = NOP;
+    }
 
     *(uint64_t*)func_ptr = (uint64_t)trmp;
 
     last_trmp++;
-    last_trmp_abs += used_abs;
     return 0;
 }
 

--- a/simple_hook.c
+++ b/simple_hook.c
@@ -13,23 +13,15 @@
 typedef uint64_t pint;
 typedef int64_t sint;
 #define WORST_CASE 			40
-#define JUMP_SIZE 			14
+#define JUMP_SIZE 			sizeof(JMP_ABS)
 #define TRMPS_ARRAY_SIZE	10240
 #elif defined(__i386) || defined(_M_IX86)
 typedef uint32_t pint;
 typedef int32_t sint;
 #define WORST_CASE 			29
-#define JUMP_SIZE 			5
+#define JUMP_SIZE 			sizeof(JMP_REL)
 #define TRMPS_ARRAY_SIZE	10240
 #endif
-
-#define IS_RET(hde) (hde.opcode == 0xC3||hde.opcode == 0xCB||hde.opcode == 0xC2||hde.opcode == 0xCA)
-#define IS_RELATIVE8(hde) ((hde.flags & F_DISP8) || ((hde.flags & F_IMM8) && (hde.flags & F_RELATIVE)))
-#define IS_RELATIVE16(hde) ((hde.flags & F_DISP16) || ((hde.flags & F_IMM16) && (hde.flags & F_RELATIVE)))
-#define IS_RELATIVE32(hde) (((hde.flags & F_DISP32) && !hde.modrm_mod && (hde.modrm_mod == 5 || hde.modrm_mod == 13)) || \
-    ((hde.flags & F_IMM32) && (hde.flags & F_RELATIVE)))
-#define IS_RELATIVE64(hde) ((hde.flags & F_IMM64) && (hde.flags & F_RELATIVE))
-#define IS_CALL_OR_JUMP(hde) (hde.opcode == 0xE9 || hde.opcode == 0xE8 || hde.opcode == 0xFF)
 
 const uint8_t NOP = 0x90;
 
@@ -40,9 +32,6 @@ static void initializeTrampolines(void) {
 	trmps = mmap(NULL, (WORST_CASE * TRMPS_ARRAY_SIZE) + (JUMP_SIZE * TRMPS_ARRAY_SIZE),
 		        PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
 }
-
-#if defined(__x86_64__) || defined(_M_X64)
-#include "HDE/hde64.h"
 
 int Hook(void* target, void* replacement, void** func_ptr) {
     TRAMPOLINE ct;
@@ -56,7 +45,7 @@ int Hook(void* target, void* replacement, void** func_ptr) {
     	if (last_trmp + 1 > TRMPS_ARRAY_SIZE) return -3;
     }
 
-    void* trmp = (void*)((uint64_t)trmps + last_trmp * WORST_CASE);
+    void* trmp = (void*)((pint)trmps + last_trmp * WORST_CASE);
 
     ct.pTarget     = target;
     ct.pDetour     = replacement;
@@ -68,92 +57,28 @@ int Hook(void* target, void* replacement, void** func_ptr) {
 
     page_size = sysconf(_SC_PAGESIZE);
     if (page_size == -1) return errno;
-    res = mprotect((void*)((uint64_t)target & ~(page_size-1)), page_size, PROT_READ | PROT_WRITE | PROT_EXEC);
+    res = mprotect((void*)((pint)target & ~(page_size-1)), page_size, PROT_READ | PROT_WRITE | PROT_EXEC);
     if (res) return errno;
 
+#if defined(__x86_64__) || defined(_M_X64)
     PJMP_ABS pJmp = (PJMP_ABS)target;
     pJmp->opcode0 = 0xFF;
     pJmp->opcode1 = 0x25;
     pJmp->dummy   = 0;
-    pJmp->address = replacement;
+    pJmp->address = (pint)replacement;
+#else
+    PJMP_REL pJmp = (PJMP_REL)target;
+    pJmp->opcode  = 0xE9;
+    pJmp->operand = (pint)replacement - ( (pint)target + sizeof(JMP_REL) );
+#endif
 
     int difference = ct.newIPs[ ct.nIP - 1 ];
-    for (int i=sizeof(JMP_ABS); i<difference; i++) {
-        *(uint8_t*)((uint64_t)target + i) = NOP;
+    for (int i=JUMP_SIZE; i<difference; i++) {
+        *((uint8_t*)target + i) = NOP;
     }
 
-    *(uint64_t*)func_ptr = (uint64_t)trmp;
+    *func_ptr = trmp;
 
     last_trmp++;
     return 0;
 }
-
-#elif defined(__i386) || defined(_M_IX86)
-#include "HDE/hde32.h"
-
-const uint8_t JMP = 0xE9;
-
-int Hook(void* target, void* replacement, void** func_ptr) {
-    int was_ret = 0, total_length = 0, difference = 0, res, page_size;
-    hde32s hde;
-    
-    while (total_length < 5) {
-        total_length += hde32_disasm((void*)((uint32_t)target + total_length), &hde);
-        if ((hde.flags & F_ERROR) || was_ret) return NULL;
-        else if (IS_RET(hde)) was_ret = 1; // We want to stay within the function.
-    }
-
-    difference = total_length - 5;
-    void* trmp = mmap(NULL, total_length + 5,
-        PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-    if (!trmp) return errno;
-    
-    // Copy the real function's initial bytes to our trampoline.
-    memcpy(trmp, target, total_length);
-
-    // Check if we have any relative jumps we have to fix.
-    for (int len = 0; len < total_length; ) {
-    	// TODO: This could still fail for disp8 and disp16. Need to check out other hooking libs.
-        len += hde32_disasm((void*)((uint32_t)trmp + len), &hde);
-        if (IS_RELATIVE8(hde)) {
-        	*(uint8_t*)((uint32_t)trmp + len - 1) -= (uint32_t)trmp - (uint32_t)target;
-        }
-        else if (IS_RELATIVE16(hde)) {
-        	*(uint16_t*)((uint32_t)trmp + len - 2) -= (uint32_t)trmp - (uint32_t)target;
-        }
-        else if (IS_RELATIVE32(hde)) {
-        	*(uint32_t*)((uint32_t)trmp + len - 4) -= (uint32_t)trmp - (uint32_t)target;
-        }
-    }
-
-    // Temporarily make the .text page in question writable.
-    page_size = sysconf(_SC_PAGESIZE);
-    if (page_size == -1) return errno;
-    res = mprotect((void*)((uint32_t)target & ~(page_size-1)), page_size, PROT_READ | PROT_WRITE | PROT_EXEC);
-    if (res) return errno;
-
-    // Create JMP to our replacement function.
-    *(uint8_t*)target = JMP;
-    *(int32_t*)((uint32_t)target + 1) = (int32_t)replacement - (int32_t)target - 5;
-
-    // NOP out the rest, if any, out of courtesy. Removes broken opcodes.
-    for (int i = 0; i < difference; i++)
-        *(uint8_t*)((uint32_t)target + 5 + i) = NOP;
-    
-    // NOTE: Apparently POSIX doesn't provide a way to get the protection flags for a page,
-    //       so we can't restore without having to make assumptions. I think you could parse
-    //       /proc/self/maps, but meh. Assuming it's read and exec. Perhaps we should just
-    //       leave it as it is? TODO
-    res = mprotect((void*)((uint32_t)target & ~(page_size-1)), page_size, PROT_READ | PROT_EXEC);
-    if (res) return errno;
-
-    // Create a jump back to the rest of the real function on trampoline.
-    *(char*)((uint32_t)trmp + total_length) = JMP;
-    *(int32_t*)((uint32_t)trmp + total_length + 1) = (int32_t)target - (int32_t)trmp - 5;
-
-    *(uint32_t*)func_ptr = (uint32_t)trmp;
-
-    return 0;
-}
-
-#endif

--- a/simple_hook.h
+++ b/simple_hook.h
@@ -2,5 +2,6 @@
 #define SIMPLE_HOOK_H
 
 int Hook(void* target, void* replacement, void** func_ptr);
+int seek_hook_slot( int offset );
 
 #endif /* SIMPLE_HOOK_H */

--- a/trampoline.c
+++ b/trampoline.c
@@ -1,0 +1,284 @@
+﻿/*
+ *  MinHook - The Minimalistic API Hooking Library for x64/x86
+ *  Copyright (C) 2009-2017 Tsuda Kageyu.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ *  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *  PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER
+ *  OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ *  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string.h>
+
+#ifndef ARRAYSIZE
+    #define ARRAYSIZE(A) (sizeof(A)/sizeof((A)[0]))
+#endif
+
+#if defined(_M_X64) || defined(__x86_64__)
+    #include "./HDE/hde64.h"
+    typedef hde64s HDE;
+    #define HDE_DISASM(code, hs) hde64_disasm(code, hs)
+#else
+    #include "./HDE/hde32.h"
+    typedef hde32s HDE;
+    #define HDE_DISASM(code, hs) hde32_disasm(code, hs)
+#endif
+
+#include "trampoline.h"
+
+#if defined(_M_X64) || defined(__x86_64__)
+    #define MEMORY_SLOT_SIZE 64
+#else
+    #define MEMORY_SLOT_SIZE 32
+#endif
+
+// Maximum size of a trampoline function.
+#if defined(_M_X64) || defined(__x86_64__)
+    #define TRAMPOLINE_MAX_SIZE (MEMORY_SLOT_SIZE - sizeof(JMP_ABS))
+#else
+    #define TRAMPOLINE_MAX_SIZE MEMORY_SLOT_SIZE
+#endif
+
+//-------------------------------------------------------------------------
+BOOL CreateTrampolineFunction(PTRAMPOLINE ct)
+{
+#if defined(_M_X64) || defined(__x86_64__)
+    CALL_ABS call = {
+        0xFF, 0x15, 0x00000002, // FF15 00000002: CALL [RIP+8]
+        0xEB, 0x08,             // EB 08:         JMP +10
+        0x0000000000000000ULL   // Absolute destination address
+    };
+    JMP_ABS jmp = {
+        0xFF, 0x25, 0x00000000, // FF25 00000000: JMP [RIP+6]
+        0x0000000000000000ULL   // Absolute destination address
+    };
+    JCC_ABS jcc = {
+        0x70, 0x0E,             // 7* 0E:         J** +16
+        0xFF, 0x25, 0x00000000, // FF25 00000000: JMP [RIP+6]
+        0x0000000000000000ULL   // Absolute destination address
+    };
+#else
+    CALL_REL call = {
+        0xE8,                   // E8 xxxxxxxx: CALL +5+xxxxxxxx
+        0x00000000              // Relative destination address
+    };
+    JMP_REL jmp = {
+        0xE9,                   // E9 xxxxxxxx: JMP +5+xxxxxxxx
+        0x00000000              // Relative destination address
+    };
+    JCC_REL jcc = {
+        0x0F, 0x80,             // 0F8* xxxxxxxx: J** +6+xxxxxxxx
+        0x00000000              // Relative destination address
+    };
+#endif
+
+    UINT8     oldPos   = 0;
+    UINT8     newPos   = 0;
+    ULONG_PTR jmpDest  = 0;     // Destination address of an internal jump.
+    BOOL      finished = FALSE; // Is the function completed?
+#if defined(_M_X64) || defined(__x86_64__)
+    UINT8     instBuf[16];
+#endif
+
+    ct->patchAbove = FALSE;
+    ct->nIP        = 0;
+
+    do
+    {
+        HDE       hs;
+        UINT      copySize;
+        LPVOID    pCopySrc;
+        ULONG_PTR pOldInst = (ULONG_PTR)ct->pTarget     + oldPos;
+        ULONG_PTR pNewInst = (ULONG_PTR)ct->pTrampoline + newPos;
+
+        copySize = HDE_DISASM((LPVOID)pOldInst, &hs);
+        if (hs.flags & F_ERROR)
+            return FALSE;
+
+        pCopySrc = (LPVOID)pOldInst;
+        if (oldPos >= sizeof(jmp))
+        {
+            // The trampoline function is long enough.
+            // Complete the function with the jump to the target function.
+#if defined(_M_X64) || defined(__x86_64__)
+            jmp.address = pOldInst;
+#else
+            jmp.operand = (UINT32)(pOldInst - (pNewInst + sizeof(jmp)));
+#endif
+            pCopySrc = &jmp;
+            copySize = sizeof(jmp);
+
+            finished = TRUE;
+        }
+#if defined(_M_X64) || defined(__x86_64__)
+        else if ((hs.modrm & 0xC7) == 0x05)
+        {
+            // Instructions using RIP relative addressing. (ModR/M = 00???101B)
+
+            // Modify the RIP relative address.
+            PUINT32 pRelAddr;
+
+            // Avoid using memcpy to reduce the footprint.
+#ifndef _MSC_VER
+            memcpy(instBuf, (LPBYTE)pOldInst, copySize);
+#else
+            __movsb(instBuf, (LPBYTE)pOldInst, copySize);
+#endif
+            pCopySrc = instBuf;
+
+            // Relative address is stored at (instruction length - immediate value length - 4).
+            pRelAddr = (PUINT32)(instBuf + hs.len - ((hs.flags & 0x3C) >> 2) - 4);
+            *pRelAddr
+                = (UINT32)((pOldInst + hs.len + (INT32)hs.disp.disp32) - (pNewInst + hs.len));
+
+            // Complete the function if JMP (FF /4).
+            if (hs.opcode == 0xFF && hs.modrm_reg == 4)
+                finished = TRUE;
+        }
+#endif
+        else if (hs.opcode == 0xE8)
+        {
+            // Direct relative CALL
+            ULONG_PTR dest = pOldInst + hs.len + (INT32)hs.imm.imm32;
+#if defined(_M_X64) || defined(__x86_64__)
+            call.address = dest;
+#else
+            call.operand = (UINT32)(dest - (pNewInst + sizeof(call)));
+#endif
+            pCopySrc = &call;
+            copySize = sizeof(call);
+        }
+        else if ((hs.opcode & 0xFD) == 0xE9)
+        {
+            // Direct relative JMP (EB or E9)
+            ULONG_PTR dest = pOldInst + hs.len;
+
+            if (hs.opcode == 0xEB) // isShort jmp
+                dest += (INT8)hs.imm.imm8;
+            else
+                dest += (INT32)hs.imm.imm32;
+
+            // Simply copy an internal jump.
+            if ((ULONG_PTR)ct->pTarget <= dest
+                && dest < ((ULONG_PTR)ct->pTarget + sizeof(JMP_REL)))
+            {
+                if (jmpDest < dest)
+                    jmpDest = dest;
+            }
+            else
+            {
+#if defined(_M_X64) || defined(__x86_64__)
+                jmp.address = dest;
+#else
+                jmp.operand = (UINT32)(dest - (pNewInst + sizeof(jmp)));
+#endif
+                pCopySrc = &jmp;
+                copySize = sizeof(jmp);
+
+                // Exit the function If it is not in the branch
+                finished = (pOldInst >= jmpDest);
+            }
+        }
+        else if ((hs.opcode & 0xF0) == 0x70
+            || (hs.opcode & 0xFC) == 0xE0
+            || (hs.opcode2 & 0xF0) == 0x80)
+        {
+            // Direct relative Jcc
+            ULONG_PTR dest = pOldInst + hs.len;
+
+            if ((hs.opcode & 0xF0) == 0x70      // Jcc
+                || (hs.opcode & 0xFC) == 0xE0)  // LOOPNZ/LOOPZ/LOOP/JECXZ
+                dest += (INT8)hs.imm.imm8;
+            else
+                dest += (INT32)hs.imm.imm32;
+
+            // Simply copy an internal jump.
+            if ((ULONG_PTR)ct->pTarget <= dest
+                && dest < ((ULONG_PTR)ct->pTarget + sizeof(JMP_REL)))
+            {
+                if (jmpDest < dest)
+                    jmpDest = dest;
+            }
+            else if ((hs.opcode & 0xFC) == 0xE0)
+            {
+                // LOOPNZ/LOOPZ/LOOP/JCXZ/JECXZ to the outside are not supported.
+                return FALSE;
+            }
+            else
+            {
+                UINT8 cond = ((hs.opcode != 0x0F ? hs.opcode : hs.opcode2) & 0x0F);
+#if defined(_M_X64) || defined(__x86_64__)
+                // Invert the condition in x64 mode to simplify the conditional jump logic.
+                jcc.opcode  = 0x71 ^ cond;
+                jcc.address = dest;
+#else
+                jcc.opcode1 = 0x80 | cond;
+                jcc.operand = (UINT32)(dest - (pNewInst + sizeof(jcc)));
+#endif
+                pCopySrc = &jcc;
+                copySize = sizeof(jcc);
+            }
+        }
+        else if ((hs.opcode & 0xFE) == 0xC2)
+        {
+            // RET (C2 or C3)
+
+            // Complete the function if not in a branch.
+            finished = (pOldInst >= jmpDest);
+        }
+
+        // Can't alter the instruction length in a branch.
+        if (pOldInst < jmpDest && copySize != hs.len)
+            return FALSE;
+
+        // Trampoline function is too large.
+        if ((newPos + copySize) > TRAMPOLINE_MAX_SIZE)
+            return FALSE;
+
+        // Trampoline function has too many instructions.
+        if (ct->nIP >= ARRAYSIZE(ct->oldIPs))
+            return FALSE;
+
+        ct->oldIPs[ct->nIP] = oldPos;
+        ct->newIPs[ct->nIP] = newPos;
+        ct->nIP++;
+
+        // Avoid using memcpy to reduce the footprint.
+#ifndef _MSC_VER
+        memcpy((LPBYTE)ct->pTrampoline + newPos, pCopySrc, copySize);
+#else
+        __movsb((LPBYTE)ct->pTrampoline + newPos, pCopySrc, copySize);
+#endif
+        newPos += copySize;
+        oldPos += hs.len;
+    }
+    while (!finished);
+
+#if defined(_M_X64) || defined(__x86_64__)
+    // Create a relay function.
+    jmp.address = (ULONG_PTR)ct->pDetour;
+
+    ct->pRelay = (LPBYTE)ct->pTrampoline + newPos;
+    memcpy(ct->pRelay, &jmp, sizeof(jmp));
+#endif
+
+    return TRUE;
+}

--- a/trampoline.h
+++ b/trampoline.h
@@ -1,0 +1,120 @@
+﻿/*
+ *  MinHook - The Minimalistic API Hooking Library for x64/x86
+ *  Copyright (C) 2009-2017 Tsuda Kageyu.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ *  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ *  PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER
+ *  OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ *  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#pragma pack(push, 1)
+
+#include <stdint.h>
+#define FALSE 0
+#define TRUE 1
+typedef int8_t INT8;
+typedef int32_t INT32;
+typedef uint8_t UINT8;
+typedef uint32_t UINT32;
+typedef uint64_t UINT64;
+typedef uint32_t* PUINT32;
+typedef uint8_t* ULONG_PTR; // unsigned long in 32
+typedef int BOOL;
+typedef unsigned int UINT;
+typedef void* LPVOID;
+typedef uint8_t* LPBYTE;
+
+// Structs for writing x86/x64 instructions.
+
+// 8-bit relative jump.
+typedef struct _JMP_REL_SHORT
+{
+    UINT8  opcode;      // EB xx: JMP +2+xx
+    UINT8  operand;
+} JMP_REL_SHORT, *PJMP_REL_SHORT;
+
+// 32-bit direct relative jump/call.
+typedef struct _JMP_REL
+{
+    UINT8  opcode;      // E9/E8 xxxxxxxx: JMP/CALL +5+xxxxxxxx
+    UINT32 operand;     // Relative destination address
+} JMP_REL, *PJMP_REL, CALL_REL;
+
+// 64-bit indirect absolute jump.
+typedef struct _JMP_ABS
+{
+    UINT8  opcode0;     // FF25 00000000: JMP [+6]
+    UINT8  opcode1;
+    UINT32 dummy;
+    UINT64 address;     // Absolute destination address
+} JMP_ABS, *PJMP_ABS;
+
+// 64-bit indirect absolute call.
+typedef struct _CALL_ABS
+{
+    UINT8  opcode0;     // FF15 00000002: CALL [+6]
+    UINT8  opcode1;
+    UINT32 dummy0;
+    UINT8  dummy1;      // EB 08:         JMP +10
+    UINT8  dummy2;
+    UINT64 address;     // Absolute destination address
+} CALL_ABS;
+
+// 32-bit direct relative conditional jumps.
+typedef struct _JCC_REL
+{
+    UINT8  opcode0;     // 0F8* xxxxxxxx: J** +6+xxxxxxxx
+    UINT8  opcode1;
+    UINT32 operand;     // Relative destination address
+} JCC_REL;
+
+// 64bit indirect absolute conditional jumps that x64 lacks.
+typedef struct _JCC_ABS
+{
+    UINT8  opcode;      // 7* 0E:         J** +16
+    UINT8  dummy0;
+    UINT8  dummy1;      // FF25 00000000: JMP [+6]
+    UINT8  dummy2;
+    UINT32 dummy3;
+    UINT64 address;     // Absolute destination address
+} JCC_ABS;
+
+#pragma pack(pop)
+
+typedef struct _TRAMPOLINE
+{
+    LPVOID pTarget;         // [In] Address of the target function.
+    LPVOID pDetour;         // [In] Address of the detour function.
+    LPVOID pTrampoline;     // [In] Buffer address for the trampoline and relay function.
+
+#if defined(_M_X64) || defined(__x86_64__)
+    LPVOID pRelay;          // [Out] Address of the relay function.
+#endif
+    BOOL   patchAbove;      // [Out] Should use the hot patch area?
+    UINT   nIP;             // [Out] Number of the instruction boundaries.
+    UINT8  oldIPs[12];       // [Out] Instruction boundaries of the target function.
+    UINT8  newIPs[12];       // [Out] Instruction boundaries of the trampoline function.
+} TRAMPOLINE, *PTRAMPOLINE;
+
+BOOL CreateTrampolineFunction(PTRAMPOLINE ct);


### PR DESCRIPTION
- rewrote Hook() function using MinHook's CreateTrampoline (https://github.com/MinoMino/minqlx/commit/695d75e9b182db89d8474f2e17b2e51b0001fe8a)
- fixed bug, when long living server could crash after map change/restart (https://github.com/MinoMino/minqlx/commit/9a983e0a4dfd6870b78562e5cc3a10e0dbb78b97). It can happen when Hook returns -3 when executing HookVm
- reduced memory usage for trampolines (https://github.com/MinoMino/minqlx/commit/84057170c220ede732a9afaf810a2656b5b3b633)
- better support for hooking in x86 hosts (https://github.com/MinoMino/minqlx/commit/4bfcb583e3fa6952cf7593b915f8456dea8720b4)