### PR TITLE
Update the Makefile to be compatible with Python 3.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,15 @@ BINDIR = bin
 CC = gcc
 CFLAGS += -shared -std=gnu11
 LDFLAGS_NOPY += -ldl
-LDFLAGS += $(shell python3-config --libs)
+
+# First command is required for Python 3.8 and will fail for Python < 3.8
+PYTHON_LD_FLAGS = $(shell python3-config --libs --embed)
+ifneq ($(.SHELLSTATUS), 0)
+	# This command is required for Python < 3.8
+	PYTHON_LD_FLAGS = $(shell python3-config --libs)
+endif
+
+LDFLAGS += $(PYTHON_LD_FLAGS)
 SOURCES_NOPY += dllmain.c commands.c simple_hook.c hooks.c misc.c maps_parser.c trampoline.c patches.c
 SOURCES += dllmain.c commands.c python_embed.c python_dispatchers.c simple_hook.c hooks.c misc.c maps_parser.c trampoline.c patches.c
 OBJS = $(SOURCES:.c=.o)


### PR DESCRIPTION
The usage of `python3-config` has changed in Python 3.8 as described in [1].

The suggested way by the authors to treat this in a backward compatible
fashion is to try the 3.8 command `python3-config --libs --embed` and if it
fails (because the installation is pre 3.8), then execute `python3-config
--libs`.

The `$(.SHELLSTATUS)` variable requries GNU Make >= 4.2 (released on
2016-05-22).

[1] https://docs.python.org/3.8/whatsnew/3.8.html#debug-build-uses-the-same-abi-as-release-build