### PR TITLE
provisional try to make minqlx independent from redis v2

### DIFF
--- a/python/minqlx/database.py
+++ b/python/minqlx/database.py
@@ -313,3 +313,56 @@ class Redis(AbstractDatabase):
             if Redis._pool:
                 Redis._pool.disconnect()
                 Redis._pool = None
+
+    def mset(self, *args, **kwargs):
+        mapping = {}
+        if args:
+            if len(args) != 1 or not isinstance(args[0], dict):
+                raise redis.RedisError("MSET requires **kwargs or a single dict arg")
+            mapping.update(args[0])
+
+        if kwargs:
+            mapping.update(kwargs)
+
+        return self.r.mset(mapping)
+
+    def msetnx(self, *args, **kwargs):
+        mapping = {}
+        if args:
+            if len(args) != 1 or not isinstance(args[0], dict):
+                raise redis.RedisError("MSETNX requires **kwargs or a single dict arg")
+            mapping.update(args[0])
+
+        if kwargs:
+            mapping.update(kwargs)
+
+        return self.r.msetnx(mapping)
+
+    def zadd(self, name, *args, **kwargs):
+        if redis.VERSION < (3, 0):
+            return self.r.zadd(name, *args, **kwargs)
+
+        if isinstance(args[0], dict):
+            return self.r.zadd(name, *args, **kwargs)
+
+        mapping = {}
+        if len(args) > 0:
+            if len(args) % 2 != 0:
+                raise redis.RedisError("ZADD requires an equal number of values and scores")
+
+            for i in range(0, len(args), 2):
+                mapping[args[i + 1]] = args[i]
+
+        return self.r.zadd(name, mapping, **kwargs)
+
+    def zincrby(self, name, value_or_amount, amount_or_value=1):
+        if isinstance(amount_or_value, (int, float)):
+            value = value_or_amount
+            amount = amount_or_value
+        else:
+            value = amount_or_value
+            amount = value_or_amount
+
+        if redis.VERSION < (3, 0):
+            return self.r.zincrby(name, value, amount)  # pylint: disable=W1114
+        return self.r.zincrby(name, amount, value)  # pylint: disable=W1114

--- a/python/minqlx/database.py
+++ b/python/minqlx/database.py
@@ -356,7 +356,7 @@ class Redis(AbstractDatabase):
         return self.r.zadd(name, mapping, **kwargs)
 
     def zincrby(self, name, value_or_amount, amount_or_value=1):
-        if isinstance(amount_or_value, (int, float)):
+        if not isinstance(value_or_amount, (int, float)):
             value = value_or_amount
             amount = amount_or_value
         else:
@@ -366,3 +366,27 @@ class Redis(AbstractDatabase):
         if redis.VERSION < (3, 0):
             return self.r.zincrby(name, value, amount)  # pylint: disable=W1114
         return self.r.zincrby(name, amount, value)  # pylint: disable=W1114
+
+    def setex(self, name, value_or_time, time_or_value):
+        if not isinstance(value_or_time, (int, timedelta)):
+            value = value_or_time
+            time = time_or_value
+        else:
+            value = time_or_value
+            time = value_or_time
+
+        if redis.VERSION < (3, 0):
+            return self.r.setex(name, time, value)  # pylint: disable=W1114
+        return self.r.setex(name, value, time)  # pylint: disable=W1114
+
+    def lrem(self, name, value_or_count, num_or_value=0):
+        if not isinstance(value_or_count, int):
+            value = value_or_count
+            count = num_or_value
+        else:
+            value = num_or_value
+            count = value_or_count
+
+        if redis.VERSION < (3, 0):
+            return self.r.lrem(name, count, value)  # pylint: disable=W1114
+        return self.r.lrem(name, value, count)  # pylint: disable=W1114

--- a/python/minqlx/database.py
+++ b/python/minqlx/database.py
@@ -367,18 +367,6 @@ class Redis(AbstractDatabase):
             return self.r.zincrby(name, value, amount)  # pylint: disable=W1114
         return self.r.zincrby(name, amount, value)  # pylint: disable=W1114
 
-    def setex(self, name, value_or_time, time_or_value):
-        if not isinstance(value_or_time, (int, timedelta)):
-            value = value_or_time
-            time = time_or_value
-        else:
-            value = time_or_value
-            time = value_or_time
-
-        if redis.VERSION < (3, 0):
-            return self.r.setex(name, time, value)  # pylint: disable=W1114
-        return self.r.setex(name, value, time)  # pylint: disable=W1114
-
     def lrem(self, name, value_or_count, num_or_value=0):
         if not isinstance(value_or_count, int):
             value = value_or_count


### PR DESCRIPTION
This is a first try to make minqlx redis less reliant on redis v2 being installed. I tried to incorporate backward and forward compatibility as much as possible. I did not yet try this out, though. Basic information point were the information from redis v3 page: https://pypi.org/project/redis/3.0.0/ I ignored SETEX, LREM, TTL, and PTTL changes. Not sure whether any plugin uses these features.