### PR TITLE
Update python_embed.c

### DIFF
--- a/python_embed.c
+++ b/python_embed.c
@@ -1,4 +1,5 @@
 #include <Python.h>
+#include <patchlevel.h>
 #include <structmember.h>
 #include <structseq.h>
 #include <stdlib.h>
@@ -1499,7 +1500,11 @@ void replace_item_core(gentity_t* ent, int item_id) {
 static PyObject* PyMinqlx_ReplaceItems(PyObject* self, PyObject* args) {
     PyObject *arg1, *arg2 ;
     int entity_id = 0, item_id = 0;
+    #if PY_MINOR_VERSION < 7
     char *entity_classname = NULL, *item_classname = NULL;
+    #else
+    const char *entity_classname = NULL, *item_classname = NULL;
+    #endif
     gentity_t* ent;
 
 
@@ -1914,7 +1919,9 @@ PyMinqlx_InitStatus_t PyMinqlx_Initialize(void) {
     Py_SetProgramName(PYTHON_FILENAME);
     PyImport_AppendInittab("_minqlx", &PyMinqlx_InitModule);
     Py_Initialize();
+    #if PY_MINOR_VERSION < 7
     PyEval_InitThreads();
+    #endif
 
     // Add the main module.
     PyObject* main_module = PyImport_AddModule("__main__");

--- a/python_embed.c
+++ b/python_embed.c
@@ -1500,7 +1500,7 @@ void replace_item_core(gentity_t* ent, int item_id) {
 static PyObject* PyMinqlx_ReplaceItems(PyObject* self, PyObject* args) {
     PyObject *arg1, *arg2 ;
     int entity_id = 0, item_id = 0;
-    #if PY_MINOR_VERSION < 7
+    #if PY_VERSION_HEX < ((3 << 24) | (7 << 16))
     char *entity_classname = NULL, *item_classname = NULL;
     #else
     const char *entity_classname = NULL, *item_classname = NULL;
@@ -1919,7 +1919,7 @@ PyMinqlx_InitStatus_t PyMinqlx_Initialize(void) {
     Py_SetProgramName(PYTHON_FILENAME);
     PyImport_AppendInittab("_minqlx", &PyMinqlx_InitModule);
     Py_Initialize();
-    #if PY_MINOR_VERSION < 7
+    #if PY_VERSION_HEX < ((3 << 24) | (7 << 16))
     PyEval_InitThreads();
     #endif
 


### PR DESCRIPTION
fixed two things that changed with python version 3.7:
- PyUnicode_AsUTF8 now returns a const char* rather than just a char*
- PyEval_InitThreads() does nothing, since it's now called in Py_Initialize(), and will be removed with python version 3.11