### PR TITLE
added new hook, handler and dispatcher for any damage events happening

### DIFF
--- a/hooks.c
+++ b/hooks.c
@@ -251,6 +251,7 @@ void __cdecl My_G_Damage(
 
     if (attacker && attacker->client) {
         attacker_id = attacker->client->ps.clientNum;
+    }
 
     DamageDispatcher(target_id, attacker_id, damage, dflags, mod);
 }

--- a/hooks.c
+++ b/hooks.c
@@ -247,11 +247,9 @@ void __cdecl My_G_Damage(
         return;
     }
 
-    target_id = target->client->ps.clientNum;
+    target_id = target - g_entities;
 
-    if (attacker && attacker->client) {
-        attacker_id = attacker->client->ps.clientNum;
-    }
+    attacker_id = attacker - g_entities;
 
     DamageDispatcher(target_id, attacker_id, damage, dflags, mod);
 }

--- a/hooks.c
+++ b/hooks.c
@@ -249,7 +249,7 @@ void __cdecl My_G_Damage(
 
     target_id = target->client->ps.clientNum;
 
-    if attacker && attacker->client {
+    if (attacker && attacker->client) {
         attacker_id = attacker->client->ps.clientNum;
 
     DamageDispatcher(target_id, attacker_id, damage, dflags, mod);)

--- a/hooks.c
+++ b/hooks.c
@@ -223,6 +223,37 @@ void __cdecl My_G_StartKamikaze(gentity_t* ent) {
     if (client_id != -1)
         KamikazeExplodeDispatcher(client_id, is_used_on_demand);
 }
+
+void __cdecl My_G_Damage(
+    gentity_t* target, // entity that is being damaged
+    gentity_t* inflictor, // entity that is causing the damage
+    gentity_t* attacker, // entity that caused the inflictor to damage targ
+    vec3_t dir, // direction of the attack for knockback
+    vec3_t point, // point at which the damage is being inflicted, used for headshots
+    int damage, // amount of damage being inflicted
+    int dflags, // these flags are used to control how T_Damage works
+    int mod // means_of_death indicator
+    ) {
+    int target_id;
+    int attacker_id = -1;
+
+    G_Damage(target, inflictor, attacker, dir, point, damage, dflags, mod);
+
+    if (!target) {
+        return;
+    }
+
+    if (!target->client) {
+        return;
+    }
+
+    target_id = target->client->ps.clientNum;
+
+    if attacker && attacker->client {
+        attacker_id = attacker->client->ps.clientNum;
+
+    DamageDispatcher(target_id, attacker_id, damage, dflags, mod);)
+}
 #endif
 
 // Hook static functions. Can be done before program even runs.
@@ -340,6 +371,13 @@ void HookVm(void) {
     res = Hook((void*)ClientSpawn, My_ClientSpawn, (void*)&ClientSpawn);
     if (res) {
         DebugPrint("ERROR: Failed to hook ClientSpawn: %d\n", res);
+        failed = 1;
+    }
+    count++;
+
+    res = Hook((void*)G_Damage, My_G_Damage, (void*)&G_Damage);
+    if (res) {
+        DebugPrint("ERROR: Failed to hook G_Damage: %d\n", res);
         failed = 1;
     }
     count++;

--- a/hooks.c
+++ b/hooks.c
@@ -252,7 +252,7 @@ void __cdecl My_G_Damage(
     if (attacker && attacker->client) {
         attacker_id = attacker->client->ps.clientNum;
 
-    DamageDispatcher(target_id, attacker_id, damage, dflags, mod);)
+    DamageDispatcher(target_id, attacker_id, damage, dflags, mod);
 }
 #endif
 

--- a/pyminqlx.h
+++ b/pyminqlx.h
@@ -61,6 +61,7 @@ extern PyObject* client_spawn_handler;
 
 extern PyObject* kamikaze_use_handler;
 extern PyObject* kamikaze_explode_handler;
+extern PyObject* damage_handler;
 
 // Custom console command handler. These are commands added through Python that can be used
 // from the console or using RCON.
@@ -91,5 +92,6 @@ void ClientSpawnDispatcher(int client_id);
 
 void KamikazeUseDispatcher(int client_id);
 void KamikazeExplodeDispatcher(int client_id, int is_used_on_demand);
+void DamageDispatcher(int target_id, int attacker_id, int damage, int dflags, int mod);
 
 #endif /* PYMINQLX_H */

--- a/python/minqlx/_events.py
+++ b/python/minqlx/_events.py
@@ -30,7 +30,7 @@ class EventDispatcher:
     to hook into events by registering an event handler.
 
     """
-    no_debug = ("frame", "set_configstring", "stats", "server_command", "death", "kill", "command", "console_print")
+    no_debug = ("frame", "set_configstring", "stats", "server_command", "death", "kill", "command", "console_print", "damage")
     need_zmq_stats_enabled = False
 
     def __init__(self):
@@ -581,6 +581,14 @@ class KamikazeExplodeDispatcher(EventDispatcher):
     def dispatch(self, player, is_used_on_demand):
         return super().dispatch(player, is_used_on_demand)
 
+class DamageDispatcher(EventDispatcher):
+    """Event that goes off when someone is inflicted with damage."""
+
+    name = "damage"
+    need_zmq_stats_enabled = False
+
+    def dispatch(self, target, attacker, damage, dflags, mod):
+        return super().dispatch(target, attacker, damage, dflags, mod)
 
 EVENT_DISPATCHERS = EventDispatcherManager()
 EVENT_DISPATCHERS.add_dispatcher(ConsolePrintDispatcher)
@@ -615,3 +623,4 @@ EVENT_DISPATCHERS.add_dispatcher(NewGameDispatcher)
 EVENT_DISPATCHERS.add_dispatcher(KillDispatcher)
 EVENT_DISPATCHERS.add_dispatcher(DeathDispatcher)
 EVENT_DISPATCHERS.add_dispatcher(UserinfoDispatcher)
+EVENT_DISPATCHERS.add_dispatcher(DamageDispatcher)

--- a/python/minqlx/_handlers.py
+++ b/python/minqlx/_handlers.py
@@ -432,13 +432,13 @@ def handle_kamikaze_explode(client_id, is_used_on_demand):
         minqlx.log_exception()
         return True
 
-def handle_damage(target, attacker, damage, dflags, mod):
-    target_player = minqlx.Player(target)
-    attacker_player = minqlx.Player(attacker) if attacker is not None else None
+def handle_damage(target_id, attacker_id, damage, dflags, mod):
+    target_player = minqlx.Player(target_id)
+    inflictor_player = minqlx.Player(attacker_id) if attacker_id is not None and attacker_id >= 0 else None
     # noinspection PyBroadException
     try:
         minqlx.EVENT_DISPATCHERS["damage"].dispatch(
-            target_player, attacker_player, damage, dflags, mod
+            target_player, inflictor_player, damage, dflags, mod
         )
     except:  # noqa: E722
         minqlx.log_exception()

--- a/python/minqlx/_handlers.py
+++ b/python/minqlx/_handlers.py
@@ -433,8 +433,8 @@ def handle_kamikaze_explode(client_id, is_used_on_demand):
         return True
 
 def handle_damage(target_id, attacker_id, damage, dflags, mod):
-    target_player = minqlx.Player(target_id)
-    inflictor_player = minqlx.Player(attacker_id) if attacker_id is not None and attacker_id >= 0 else None
+    target_player = minqlx.Player(target_id) if target_id in range(0, 64) else None
+    inflictor_player = minqlx.Player(attacker_id) if attacker_id is not None and attacker_id in range(0, 64) else None
     # noinspection PyBroadException
     try:
         minqlx.EVENT_DISPATCHERS["damage"].dispatch(

--- a/python/minqlx/_handlers.py
+++ b/python/minqlx/_handlers.py
@@ -432,6 +432,18 @@ def handle_kamikaze_explode(client_id, is_used_on_demand):
         minqlx.log_exception()
         return True
 
+def handle_damage(target, attacker, damage, dflags, mod):
+    target_player = minqlx.Player(target)
+    attacker_player = minqlx.Player(attacker) if attacker is not None else None
+    # noinspection PyBroadException
+    try:
+        minqlx.EVENT_DISPATCHERS["damage"].dispatch(
+            target_player, attacker_player, damage, dflags, mod
+        )
+    except:  # noqa: E722
+        minqlx.log_exception()
+        return True
+
 def handle_console_print(text):
     """Called whenever the server prints something to the console and when rcon is used."""
     try:
@@ -510,3 +522,4 @@ def register_handlers():
 
     minqlx.register_handler("kamikaze_use", handle_kamikaze_use)
     minqlx.register_handler("kamikaze_explode", handle_kamikaze_explode)
+    minqlx.register_handler("damage", handle_damage)

--- a/python/minqlx/_handlers.py
+++ b/python/minqlx/_handlers.py
@@ -433,14 +433,16 @@ def handle_kamikaze_explode(client_id, is_used_on_demand):
         return True
 
 def handle_damage(target_id, attacker_id, damage, dflags, mod):
-    target_player = minqlx.Player(target_id) if target_id in range(0, 64) else None
-    inflictor_player = minqlx.Player(attacker_id) if attacker_id is not None and attacker_id in range(0, 64) else None
-    # noinspection PyBroadException
+    target_player = minqlx.Player(target_id) if target_id in range(0, 64) else target_id
+    attacker_player = (
+        minqlx.Player(attacker_id) if attacker_id in range(0, 64) else attacker_id
+    )
+
     try:
         minqlx.EVENT_DISPATCHERS["damage"].dispatch(
-            target_player, inflictor_player, damage, dflags, mod
+            target_player, attacker_player, damage, dflags, mod
         )
-    except:  # noqa: E722
+    except:
         minqlx.log_exception()
         return True
 

--- a/python_dispatchers.c
+++ b/python_dispatchers.c
@@ -301,7 +301,7 @@ void DamageDispatcher(int target_id, int attacker_id, int damage, int dflags, in
 
     PyGILState_STATE gstate = PyGILState_Ensure();
 
-    PyObject* result
+    PyObject* result;
     if (attacker_id >= 0) {
         result = PyObject_CallFunction(damage_handler, "iiiii", target_id, attacker_id, damage, dflags, mod);
     } else {

--- a/python_dispatchers.c
+++ b/python_dispatchers.c
@@ -301,8 +301,13 @@ void DamageDispatcher(int target_id, int attacker_id, int damage, int dflags, in
 
     PyGILState_STATE gstate = PyGILState_Ensure();
 
-    PyObject* result = PyObject_CallFunction(damage_handler, "iiiii", target_id, attacker_id > 0 ? attacker_id : Py_None, damage, dflags, mod);
-
+    PyObject* result
+    if (attacker_id >= 0) {
+        result = PyObject_CallFunction(damage_handler, "iiiii", target_id, attacker_id, damage, dflags, mod);
+    } else {
+        result = PyObject_CallFunction(damage_handler, "iOiii", target_id, Py_None, damage, dflags, mod);
+    }
+    
     Py_XDECREF(result);
 
     PyGILState_Release(gstate);

--- a/python_dispatchers.c
+++ b/python_dispatchers.c
@@ -294,3 +294,16 @@ void KamikazeExplodeDispatcher(int client_id, int is_used_on_demand) {
 
     PyGILState_Release(gstate);
 }
+
+void DamageDispatcher(int target_id, int attacker_id, int damage, int dflags, int mod) {
+    if (!damage_handler)
+        return; // No registered handler
+
+    PyGILState_STATE gstate = PyGILState_Ensure();
+
+    PyObject* result = PyObject_CallFunction(damage_handler, "iiiii", target_id, attacker_id > 0 ? attacker_id : Py_None, damage, dflags, mod);
+
+    Py_XDECREF(result);
+
+    PyGILState_Release(gstate);
+}

--- a/python_embed.c
+++ b/python_embed.c
@@ -121,6 +121,7 @@ static PyStructSequence_Field player_state_fields[] = {
     {"powerups", "The player's powerups."},
     {"holdable", "The player's holdable item."},
     {"flight", "A struct sequence with flight parameters."},
+    {"is_chatting", "Whether the player is currently chatting."},
     {"is_frozen", "Whether the player is frozen(freezetag)."},
     {NULL}
 };
@@ -761,7 +762,8 @@ static PyObject* PyMinqlx_PlayerState(PyObject* self, PyObject* args) {
         PyLong_FromLongLong(g_entities[client_id].client->ps.stats[STAT_FLIGHT_REFUEL]));
     PyStructSequence_SetItem(state, 11, flight);
 
-    PyStructSequence_SetItem(state, 12, PyBool_FromLong(g_entities[client_id].client->ps.pm_type == 4));
+    PyStructSequence_SetItem(state, 12, PyBool_FromLong(g_entities[client_id].client->ps.eFlags & EF_TALK != 0));
+    PyStructSequence_SetItem(state, 13, PyBool_FromLong(g_entities[client_id].client->ps.pm_type == 4));
 
     return state;
 }

--- a/python_embed.c
+++ b/python_embed.c
@@ -27,6 +27,8 @@ PyObject* client_spawn_handler = NULL;
 PyObject* kamikaze_use_handler = NULL;
 PyObject* kamikaze_explode_handler = NULL;
 
+PyObject* damage_handler = NULL;
+
 static PyThreadState* mainstate;
 static int initialized = 0;
 
@@ -70,6 +72,8 @@ static handler_t handlers[] = {
 
         {"kamikaze_use",        &kamikaze_use_handler},
         {"kamikaze_explode",    &kamikaze_explode_handler},
+
+        {"damage",              &damage_handler},
 
 		{NULL, NULL}
 };
@@ -1872,6 +1876,13 @@ static PyObject* PyMinqlx_InitModule(void) {
     PyModule_AddIntMacro(module, MOD_LIGHTNING_DISCHARGE);
     PyModule_AddIntMacro(module, MOD_HMG);
     PyModule_AddIntMacro(module, MOD_RAILGUN_HEADSHOT);
+
+    // damage flags
+    PyModule_AddIntMacro(module, DAMAGE_RADIUS);
+    PyModule_AddIntMacro(module, DAMAGE_NO_ARMOR);
+    PyModule_AddIntMacro(module, DAMAGE_NO_KNOCKBACK);
+    PyModule_AddIntMacro(module, DAMAGE_NO_PROTECTION);
+    PyModule_AddIntMacro(module, DAMAGE_NO_TEAM_PROTECTION);
 
     // Initialize struct sequence types.
     PyStructSequence_InitType(&player_info_type, &player_info_desc);

--- a/python_embed.c
+++ b/python_embed.c
@@ -1503,7 +1503,11 @@ void replace_item_core(gentity_t* ent, int item_id) {
 static PyObject* PyMinqlx_ReplaceItems(PyObject* self, PyObject* args) {
     PyObject *arg1, *arg2 ;
     int entity_id = 0, item_id = 0;
+    #if PY_VERSION_HEX < ((3 << 24) | (7 << 16))
     char *entity_classname = NULL, *item_classname = NULL;
+    #else 
+    const char *entity_classname = NULL, *item_classname = NULL;
+    #endif
     gentity_t* ent;
 
 
@@ -1925,7 +1929,9 @@ PyMinqlx_InitStatus_t PyMinqlx_Initialize(void) {
     Py_SetProgramName(PYTHON_FILENAME);
     PyImport_AppendInittab("_minqlx", &PyMinqlx_InitModule);
     Py_Initialize();
+    #if PY_VERSION_HEX < ((3 << 24) | (7 << 16))
     PyEval_InitThreads();
+    #endif
 
     // Add the main module.
     PyObject* main_module = PyImport_AddModule("__main__");

--- a/python_embed.c
+++ b/python_embed.c
@@ -122,7 +122,6 @@ static PyStructSequence_Field player_state_fields[] = {
     {"powerups", "The player's powerups."},
     {"holdable", "The player's holdable item."},
     {"flight", "A struct sequence with flight parameters."},
-    {"is_chatting", "Whether the player is currently chatting."},
     {"is_frozen", "Whether the player is frozen(freezetag)."},
     {NULL}
 };
@@ -763,8 +762,7 @@ static PyObject* PyMinqlx_PlayerState(PyObject* self, PyObject* args) {
         PyLong_FromLongLong(g_entities[client_id].client->ps.stats[STAT_FLIGHT_REFUEL]));
     PyStructSequence_SetItem(state, 11, flight);
 
-    PyStructSequence_SetItem(state, 12, PyBool_FromLong(g_entities[client_id].client->ps.eFlags & EF_TALK != 0));
-    PyStructSequence_SetItem(state, 13, PyBool_FromLong(g_entities[client_id].client->ps.pm_type == 4));
+    PyStructSequence_SetItem(state, 12, PyBool_FromLong(g_entities[client_id].client->ps.pm_type == 4));
 
     return state;
 }

--- a/quake_common.h
+++ b/quake_common.h
@@ -114,7 +114,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define FL_DROPPED_ITEM 0x00001000
 
-#define DAMAGE_NO_PROTECTION 0x00000008
+// damage flags
+#define DAMAGE_RADIUS             0x00000001 // damage was indirect
+#define DAMAGE_NO_ARMOR           0x00000002 // armor does not protect from this damage
+#define DAMAGE_NO_KNOCKBACK       0x00000004 // do not affect velocity, just view angles
+#define DAMAGE_NO_PROTECTION      0x00000008 // armor, shields, invulnerability, and godmode have no effect
+#define DAMAGE_NO_TEAM_PROTECTION 0x00000010 // armor, shields, invulnerability, and godmode have no effect
 
 typedef enum {qfalse, qtrue} qboolean;
 typedef unsigned char byte;
@@ -1565,6 +1570,7 @@ char* __cdecl My_ClientConnect(int clientNum, qboolean firstTime, qboolean isBot
 void __cdecl My_ClientSpawn(gentity_t* ent);
 
 void __cdecl My_G_StartKamikaze(gentity_t* ent);
+void __cdecl My_G_Damage(gentity_t* target, gentity_t* inflictor, gentity_t* attacker, vec3_t dir, vec3_t point, int damage, int dflags, int mod);
 #endif
 
 // Custom commands added using Cmd_AddCommand during initialization.


### PR DESCRIPTION
I hooked into G_Damage and forwarded that towards python, so that python plugins now can self.add_hook("damage", self.handle_damage) in its own function. The plugin function gets
* target player (the player receiving the damage)
* attacker (optional player, that caused the damage, might be None for environmental damage inflicted)
* damage (amount of damage the target might receive)
* dflags (bitfield of damage flags, i.e. DAMAGE_NO_PROTECTION or DAMAGE_NO_TEAM_PROTECTION)
* mod (means of death, indicating where this damage might be coming from)

The events can't be stopped, and are delivered regardless of whether the target actually gets health/armor reduced, i.e. from rocket jumps with DAMAGE_NO_PROTECTION not set, or team damage in the DAMAGE_NO_TEAM_PROTECTION case. You can detect harmful team shots by this. Plugins would need to filter the events they are interested in on their own.